### PR TITLE
fix cgroup issues

### DIFF
--- a/charts/data-space-connector/Chart.yaml
+++ b/charts/data-space-connector/Chart.yaml
@@ -53,12 +53,12 @@ dependencies:
   # issuance
   - name: keycloak
     condition: keycloak.enabled
-    version: 24.6.1
-    repository: https://charts.bitnami.com/bitnami
+    version: 24.5.2
+    repository: oci://registry-1.docker.io/bitnamicharts
   # contract management
   - name: tm-forum-api
     condition: tm-forum-api.enabled
-    version: 0.14.9
+    version: 0.14.11
     repository: https://fiware.github.io/helm-charts
   - name: contract-management
     condition: contract-management.enabled

--- a/charts/data-space-connector/values.yaml
+++ b/charts/data-space-connector/values.yaml
@@ -460,6 +460,18 @@ keycloak:
     existingSecret: issuance-secret
     passwordSecretKey: keycloak-admin
     adminUser: keycloak-admin
+
+  # -- sets memory requests for keycloak
+  # increased above the bitnami defaults to prevent OOMs in linux kernel >=6.14
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+
   # -- should the db be deployed as part of the keycloak chart
   postgresql:
     enabled: false
@@ -496,6 +508,9 @@ keycloak:
         secretKeyRef:
           name: issuance-secret
           key: keycloak-admin
+    # set in accordance with the memory requests, will result in OOM otherwise
+    - name: KC_HEAP_SIZE
+      value: "1024m"
 
   # -- configuration of the realm to be imported
   realm:


### PR DESCRIPTION
Due to some changes in the linux kernel 6.14, Keycloak in the old defaults gets OOM killed on startup. The changes prevent it. TMForum APIs use a new base image to prevent issues on startup, due to the same issue.