### PR TITLE
Fix tests

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -424,6 +424,21 @@
                                     </tasks>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>patch-progress-deadline</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <exec executable="/bin/bash">
+                                            <arg value="${parent.dir}/k3s/ci-post-render.sh" />
+                                            <arg value="${project.build.directory}/k3s" />
+                                        </exec>
+                                    </tasks>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
 

--- a/k3s/ci-post-render.sh
+++ b/k3s/ci-post-render.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Helm post-renderer for CI: increase progressDeadlineSeconds on Deployments.
+#
+# On resource-constrained CI runners, init containers that wait for
+# dependencies (e.g., keycloak) can consume most of the default 600s
+# Kubernetes progress deadline, leaving insufficient time for the main
+# container to start and pass readiness checks.
+
+awk '
+/^---/ { is_deployment = 0; patched = 0 }
+/^kind: Deployment/ { is_deployment = 1 }
+/^spec:/ && is_deployment && !patched {
+    print
+    print "  progressDeadlineSeconds: 1500"
+    patched = 1
+    next
+}
+{ print }
+'

--- a/k3s/ci-post-render.sh
+++ b/k3s/ci-post-render.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
-# Helm post-renderer for CI: increase progressDeadlineSeconds on Deployments.
+# Increase progressDeadlineSeconds on all rendered Deployment manifests.
 #
 # On resource-constrained CI runners, init containers that wait for
 # dependencies (e.g., keycloak) can consume most of the default 600s
 # Kubernetes progress deadline, leaving insufficient time for the main
 # container to start and pass readiness checks.
+#
+# Usage: ci-post-render.sh <directory>
+# Patches all .yaml files in <directory> in-place.
 
-awk '
-/^---/ { is_deployment = 0; patched = 0 }
-/^kind: Deployment/ { is_deployment = 1 }
-/^spec:/ && is_deployment && !patched {
-    print
-    print "  progressDeadlineSeconds: 1500"
-    patched = 1
-    next
-}
-{ print }
-'
+set -euo pipefail
+
+TARGET_DIR="${1:?Usage: $0 <directory>}"
+
+find "$TARGET_DIR" -name '*.yaml' -print0 | while IFS= read -r -d '' file; do
+    awk '
+    /^---/ { is_deployment = 0; patched = 0 }
+    /^kind: Deployment/ { is_deployment = 1 }
+    /^spec:/ && is_deployment && !patched {
+        print
+        print "  progressDeadlineSeconds: 1500"
+        patched = 1
+        next
+    }
+    { print }
+    ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+done

--- a/k3s/ci-post-render.sh
+++ b/k3s/ci-post-render.sh
@@ -15,14 +15,21 @@ TARGET_DIR="${1:?Usage: $0 <directory>}"
 
 find "$TARGET_DIR" -name '*.yaml' -print0 | while IFS= read -r -d '' file; do
     awk '
-    /^---/ { is_deployment = 0; patched = 0 }
+    /^---/ { is_deployment = 0; patched_deploy = 0; is_job = 0; patched_job = 0 }
     /^kind: Deployment/ { is_deployment = 1 }
-    /^spec:/ && is_deployment && !patched {
+    /^kind: Job/ { is_job = 1 }
+    /^  activeDeadlineSeconds:/ && is_job { next }
+    /^spec:/ && is_deployment && !patched_deploy {
         print
         print "  progressDeadlineSeconds: 1500"
         patched = 1
         next
     }
+    /^spec:/ && is_job && !patched_job {
+        print
+        print "  activeDeadlineSeconds: 1500"
+        patched_job = 1
+        next
     { print }
     ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
 done

--- a/k3s/dsp-provider.yaml
+++ b/k3s/dsp-provider.yaml
@@ -1,3 +1,7 @@
+
+marketplace:
+  # not required in the dsp case
+  enabled: false
 fdsc-edc:
   enabled: true
   deployment:

--- a/pom.xml
+++ b/pom.xml
@@ -701,7 +701,7 @@
                                     <skipTemplate>false</skipTemplate>
                                     <templateGenerateName>true</templateGenerateName>
                                     <templateOutputDir>${project.build.directory}/k3s/dsc-provider</templateOutputDir>
-                                    <additionalArguments>--name-template=provider --namespace=provider -f ${main.basedir}/k3s/provider.yaml -f ${main.basedir}/k3s/dsp-provider.yaml --post-renderer ${main.basedir}/k3s/ci-post-render.sh --skip-tests</additionalArguments>
+                                    <additionalArguments>--name-template=provider --namespace=provider -f ${main.basedir}/k3s/provider.yaml -f ${main.basedir}/k3s/dsp-provider.yaml --skip-tests</additionalArguments>
                                 </configuration>
                             </execution>
                             <execution>
@@ -717,7 +717,7 @@
                                     <skipTemplate>false</skipTemplate>
                                     <templateGenerateName>true</templateGenerateName>
                                     <templateOutputDir>${project.build.directory}/k3s/dsc-consumer</templateOutputDir>
-                                    <additionalArguments>--name-template=consumer --namespace=consumer -f ${main.basedir}/k3s/consumer.yaml -f ${main.basedir}/k3s/consumer-auth.yaml -f ${main.basedir}/k3s/consumer-tmf.yaml -f ${main.basedir}/k3s/dsp-consumer.yaml --post-renderer ${main.basedir}/k3s/ci-post-render.sh --skip-tests</additionalArguments>
+                                    <additionalArguments>--name-template=consumer --namespace=consumer -f ${main.basedir}/k3s/consumer.yaml -f ${main.basedir}/k3s/consumer-auth.yaml -f ${main.basedir}/k3s/consumer-tmf.yaml -f ${main.basedir}/k3s/dsp-consumer.yaml --skip-tests</additionalArguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -701,7 +701,7 @@
                                     <skipTemplate>false</skipTemplate>
                                     <templateGenerateName>true</templateGenerateName>
                                     <templateOutputDir>${project.build.directory}/k3s/dsc-provider</templateOutputDir>
-                                    <additionalArguments>--name-template=provider --namespace=provider -f ${main.basedir}/k3s/provider.yaml -f ${main.basedir}/k3s/dsp-provider.yaml --skip-tests</additionalArguments>
+                                    <additionalArguments>--name-template=provider --namespace=provider -f ${main.basedir}/k3s/provider.yaml -f ${main.basedir}/k3s/dsp-provider.yaml --post-renderer ${main.basedir}/k3s/ci-post-render.sh --skip-tests</additionalArguments>
                                 </configuration>
                             </execution>
                             <execution>
@@ -717,7 +717,7 @@
                                     <skipTemplate>false</skipTemplate>
                                     <templateGenerateName>true</templateGenerateName>
                                     <templateOutputDir>${project.build.directory}/k3s/dsc-consumer</templateOutputDir>
-                                    <additionalArguments>--name-template=consumer --namespace=consumer -f ${main.basedir}/k3s/consumer.yaml -f ${main.basedir}/k3s/consumer-auth.yaml -f ${main.basedir}/k3s/consumer-tmf.yaml -f ${main.basedir}/k3s/dsp-consumer.yaml --skip-tests</additionalArguments>
+                                    <additionalArguments>--name-template=consumer --namespace=consumer -f ${main.basedir}/k3s/consumer.yaml -f ${main.basedir}/k3s/consumer-auth.yaml -f ${main.basedir}/k3s/consumer-tmf.yaml -f ${main.basedir}/k3s/dsp-consumer.yaml --post-renderer ${main.basedir}/k3s/ci-post-render.sh --skip-tests</additionalArguments>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Test fail to start often, because of the k8s progressDeadlineSeconds(10min). Keycloak often already eats up ~9min of that, which leads to the components requiring VerifiableCredentials(contract-management, fdsc-edc) to exceed the 10min deadline. With this PR, the deadline is increased with a post-renderer.