### PR TITLE
fix: add support for multiple redirect uris for lissi and eudi wallet

### DIFF
--- a/charts/data-space-connector/templates/_realm.tpl
+++ b/charts/data-space-connector/templates/_realm.tpl
@@ -202,7 +202,7 @@ this template.
           "directAccessGrantsEnabled" false
           "implicitFlowEnabled" false
           "serviceAccountsEnabled" false
-          "redirectUris" (list $lissi.redirectUri)
+          "redirectUris" (ternary (list $lissi.redirectUri) $lissi.redirectUri (kindIs "string" $lissi.redirectUri))
           "webOrigins" (list "+")
           "protocol" "openid-connect"
           "attributes" ($lissi.attributes | default dict)
@@ -218,7 +218,7 @@ this template.
           "directAccessGrantsEnabled" false
           "implicitFlowEnabled" false
           "serviceAccountsEnabled" false
-          "redirectUris" (list $eudi.redirectUri)
+          "redirectUris" (ternary (list $eudi.redirectUri) $eudi.redirectUri (kindIs "string" $eudi.redirectUri))
           "webOrigins" (list "+")
           "protocol" "openid-connect"
           "attributes" ($eudi.attributes | default dict)

--- a/charts/data-space-connector/values.yaml
+++ b/charts/data-space-connector/values.yaml
@@ -1274,7 +1274,9 @@ keycloak:
         clientId: 9c481dc3-2ad0-4fe0-881d-c32ad02fe0fc
         name: "Lissi ID Wallet"
         description: "Hardcoded clientId expected by the Lissi ID Wallet (iOS/Android)."
-        redirectUri: https://oob.lissi.io/vci-cb
+        redirectUri:
+          - https://oob.lissi.io/vci-cb
+          - https://wallet.lissi.io/lite/vci-cb
         attributes:
           oid4vci.enabled: "true"
           post.logout.redirect.uris: "+"
@@ -1285,7 +1287,8 @@ keycloak:
         clientId: wallet-dev
         name: "EUDI Reference Wallet (dev)"
         description: "Public client used by EUDI Reference Wallet (.DEV variant). PKCE + PAR + DPoP-bound access tokens."
-        redirectUri: eu.europa.ec.euidi://authorization
+        redirectUri:
+          - eu.europa.ec.euidi://authorization
         attributes:
           oid4vci.enabled: "true"
           post.logout.redirect.uris: "+"


### PR DESCRIPTION
Lissi has changed its redirect_uri, and to support multiple wallet versions at once the redirectUri field now accepts either a single string or a list of strings.